### PR TITLE
Add support for inputting only password

### DIFF
--- a/src/bwmenu/__main__.py
+++ b/src/bwmenu/__main__.py
@@ -11,6 +11,8 @@ Options:
       Filter items that match this url basename.
   -c, --clear-session
       Clear session cache.
+  -p, --password-only
+      Fill only password.
 """
 
 from docopt import docopt
@@ -38,10 +40,11 @@ def main():
         baseurl = args["--url"]
         baseurl = "" if baseurl is None else baseurl
     item = select_item(cli.items_by_url(baseurl))
-    if item.login.username is not None:
-        type_word(item.login.username, qute)
-    if item.login.username is not None and item.login.password is not None:
-        type_tab(qute)
+    if not args["--password-only"]:
+        if item.login.username is not None:
+            type_word(item.login.username, qute)
+        if item.login.username is not None and item.login.password is not None:
+            type_tab(qute)
     if item.login.password is not None:
         type_word(item.login.password, qute)
 


### PR DESCRIPTION
Hi!

I like your implementation, keep up the good work!

Small idea from me, the [qute-bitwarden](https://github.com/qutebrowser/qutebrowser/blob/master/misc/userscripts/qute-bitwarden) implements inputting only username/password, what would you say about adding this feature to bwmenu?
This PR adds support for password-only (as I use it in my workflow), if you think username-only would be also nice, please let me know and I'll add it too.

BTW, I've seen a thread on Reddit that mentions GPG usage in this project and I see it in the git history, but it seems it's gone now.
Could you say if this is dropped completely or maybe you want to reimplement it in a cleaner way?

Once more, thanks for the project!